### PR TITLE
Enumeration Serialization

### DIFF
--- a/safe-parcel/src/main/java/org/microg/safeparcel/SafeParcelUtil.java
+++ b/safe-parcel/src/main/java/org/microg/safeparcel/SafeParcelUtil.java
@@ -55,7 +55,7 @@ public final class SafeParcelUtil {
                     try {
                         writeField(object, parcel, field, flags);
                     } catch (Exception e) {
-                        Log.w(TAG, "Error writing field: " + e, e);
+                        Log.w(TAG, "Error writing field: " + e);
                     }
                 }
             }

--- a/safe-parcel/src/main/java/org/microg/safeparcel/SafeParcelUtil.java
+++ b/safe-parcel/src/main/java/org/microg/safeparcel/SafeParcelUtil.java
@@ -393,7 +393,7 @@ public final class SafeParcelUtil {
 
     private static final Map<Class<?>, Map<Integer, Enum<?>>> statefulOrdinalsMap = new HashMap<>();
 
-    private static synchronized void readEnum(SafeParcelable object, Parcel parcel, Field field, int header) throws IllegalAccessException {
+    private static void readEnum(SafeParcelable object, Parcel parcel, Field field, int header) throws IllegalAccessException {
 
         Map<Integer, Enum<?>> statefulOrdinals = null;
         synchronized (SafeParcelUtil.class) {

--- a/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/AutoTests.java
+++ b/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/AutoTests.java
@@ -44,6 +44,7 @@ public class AutoTests {
         foo1.barList.add(foo1.bar);
         foo1.barArray = new Bar[]{foo1.bar};
         foo1.intList.add(2);
+        foo1.enumType = Type.OFFLINE;
         Foo foo2 = remarshal(foo1, Foo.CREATOR);
         assertEquals(foo1, foo2);
     }

--- a/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Foo.java
+++ b/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Foo.java
@@ -33,6 +33,8 @@ class Foo extends AutoSafeParcelable {
     public Bar[] barArray = new Bar[0];
     @Field(9)
     public List<Integer> intList = new ArrayList<>();
+    @Field(10)
+    public Type enumType = Type.OFFLINE;
 
     private Foo() {
     }
@@ -57,6 +59,7 @@ class Foo extends AutoSafeParcelable {
                 ", barList=" + barList +
                 ", barArray=" + Arrays.toString(barArray) +
                 ", intList=" + intList +
+                ", enumType=" + enumType +
                 '}';
     }
 
@@ -73,12 +76,13 @@ class Foo extends AutoSafeParcelable {
                 Objects.equals(bar, foo.bar) &&
                 Objects.equals(barList, foo.barList) &&
                 Arrays.equals(barArray, foo.barArray) &&
-                Objects.equals(intList, foo.intList);
+                Objects.equals(intList, foo.intList) &&
+                Objects.equals(enumType, foo.enumType);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(versionCode, intPrivate, string, stringList, stringStringMap, bar, barList, intList);
+        int result = Objects.hash(versionCode, intPrivate, string, stringList, stringStringMap, bar, barList, intList, enumType);
         result = 31 * result + Arrays.hashCode(barArray);
         return result;
     }

--- a/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Type.java
+++ b/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Type.java
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2019, microG Project Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.microg.safeparcel.test.auto;
 
 import org.microg.safeparcel.SafeParcelable;

--- a/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Type.java
+++ b/safe-parcel/src/test/java/org/microg/safeparcel/test/auto/Type.java
@@ -1,0 +1,10 @@
+package org.microg.safeparcel.test.auto;
+
+import org.microg.safeparcel.SafeParcelable;
+
+public enum Type {
+    @SafeParcelable.Field(1)
+    ONLINE,
+    @SafeParcelable.Field(2)
+    OFFLINE
+}


### PR DESCRIPTION
I was working with SafeParcel library and noticed, that it is not supporting enums.
Enums are great language constructs, they make the code ways easier to read. 
Unfortunately in order to use them with the library, it take to convert integer to Enum and back.
The proposed code change facilitates this process.